### PR TITLE
Stringify user object

### DIFF
--- a/lib/firebase/userCookies.js
+++ b/lib/firebase/userCookies.js
@@ -9,7 +9,7 @@ export const getUserFromCookie = () => {
 }
 
 export const setUserCookie = (user) => {
-    cookies.set('auth', user, {
+    cookies.set('auth', JSON.stringify(user), {
         // firebase id tokens expire in one hour
         // set cookie expiry to match
         expires: 1 / 24,


### PR DESCRIPTION
Stringify user object for successful object storage and retrieval. I found this was necessary to properly store the cookie for retrieval within my browser (Microsoft Edge). Without this, the cookie was being created with a value of `[Object object]`.