### PR TITLE
Missing trailing forward slash

### DIFF
--- a/components/storage/UploadFile.js
+++ b/components/storage/UploadFile.js
@@ -17,7 +17,7 @@ const UploadFile = () => {
         var file = inputEl.current.files[0]
 
         // create a storage ref
-        const storageRef = ref(storage, "user_uploads" + file.name)
+        const storageRef = ref(storage, "user_uploads/" + file.name)
 
         // upload file
         const task = uploadBytesResumable(storageRef, file)


### PR DESCRIPTION
The trailing forward slash (`/`) is necessary here to properly utilize the `user_uploads` directory as stated in the tutorial.